### PR TITLE
update derive spec, remove external_nonce

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Initially it will support communication for large groups which share a public ke
 (secret key cryptography / symmetric keys), but it has also been designed to support
 forward-secure secret-key cryptography (a little like Signal's double-ratchet).
 
-box2 assumes each message is part of append-only chain, with message that have a
-unique id. Having a unique id for the "previous" message in a chain is important.
+box2 assumes each message is part of append-only chain (with a unique `feed_id`), 
+made up of backlinked messages such that each message has a unique previous message with 
+a unique id (`prev_msg_id`)
 
 ## Anatomy
 
@@ -195,13 +196,14 @@ var Derive = MakeDeriver(feed_id, prev_msg_id)
 
 function MakeDeriver (feed_id, prev_msg_id) {
   return function (key, label, length) {
-    var data = [feed_id, previous_msg_id, label]
+    var data = [feed_id, prev_msg_id, label]
     return HKDF.Expand(key, encode(data), length)
   }
 }
 ```
 
 and further:
+- `feed_id` and `prev_msg_id` are encoded in standard binary format (TODO)
 - `encode` is a shallow lenth-prefixed (SLP) encoding of an ordered list
 - `HKDF.Expand` is a hmac-like function which is specifically designed to generate random buffers of a given length.
   - HKDF-Expand uses `sha256` for hashing, a hash-length of 32 bytes, and the final Derived-Secret length is also 32 bytes.

--- a/constants.json
+++ b/constants.json
@@ -3,7 +3,8 @@
     "description": "labels used for the DeriveSecret function",
     "read_key": "key_type:read_key",
     "header_key": "key_type:header_key",
-    "body_key": "key_type:body_key"
+    "body_key": "key_type:body_key",
+    "slot_key": "key_type:slot_key"
   },
   "error_codes": {
     "boxEmptyPlainText": "box requires a non-empty plain_text",


### PR DESCRIPTION
This PR merges the changes (to the README) which were discussed in the most recent call : 
`%xllLSUjDGr3G/BQSsbhA9vMvf0G+Bn7GhglcjTwAVRI=.sha256`

I'll comment things which may need more attention