### PR TITLE
prev_msg_id null

### DIFF
--- a/derive_secret/README.md
+++ b/derive_secret/README.md
@@ -14,6 +14,13 @@ function Derive (key, feed_id, prev_msg_id, labels, length) {
 - `key` is a cryptographic key you're deriving from
 - `labels` is an Array of strings
 - `feed_id` and `prev_msg_id` are encoded in with the binary [type-format-key (TFK) encoding](../encoding/tfk.md)
+  - if there is no `prev_msg_id` (because you're publishing the first message for this feed), we say the "key" part of the tfk encoding for `prev_msg_id` is an empty buffer, e.g.
+    ```
+      01 00  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+       │  │  └────────────────────┬────────────────────────────────────────────────────────────────────────┘
+    type  │                hex encoded key
+         format 
+    ```
 - `HKDF.Expand` is a hmac-like function which is specifically designed to generate random buffers of a given length.
   - we specify `sha256` for hashing in HKDF-Expand 
   - example of a node.js implementation : [futoin-hkdf](https://www.npmjs.com/package/futoin-hkdf#hkdfexpandhash-hash_len-prk-length-info-%E2%87%92-buffer)

--- a/derive_secret/README.md
+++ b/derive_secret/README.md
@@ -14,7 +14,7 @@ function Derive (key, feed_id, prev_msg_id, labels, length) {
 - `key` is a cryptographic key you're deriving from
 - `labels` is an Array of strings
 - `feed_id` and `prev_msg_id` are encoded in with the binary [type-format-key (TFK) encoding](../encoding/tfk.md)
-  - if there is no `prev_msg_id` (because you're publishing the first message for this feed), we say the "key" part of the tfk encoding for `prev_msg_id` is an empty buffer, e.g.
+  - if there is no `prev_msg_id` (because you're publishing the first message for this feed), we say the "key" part of the tfk encoding for `prev_msg_id` is a zero buffer of the same size, e.g.
     ```
       01 00  00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
        │  │  └────────────────────┬────────────────────────────────────────────────────────────────────────┘


### PR DESCRIPTION
we don't explicitly say how to encode `prev_msg_id` if there is no previous message.

I don't think we need a test for this, unless we also want to make some vectors for TFK encoding?